### PR TITLE
Nathan & Lewis

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-npx eslint src

--- a/src/Logic/types/board/Board.ts
+++ b/src/Logic/types/board/Board.ts
@@ -189,25 +189,18 @@ export default class Board {
   }
   //================================================= BOARD INTERACTION END
 
-  // static getHorizontalLine<T = Cell>(board: Cell[][], line: number): T[]
   static getHorizontalLine<T>(
-    board: Cell[][],
+    board: Cell[][] | TileOnBoard[][],
     line: number,
     parser?: CellParserCallback<T>
-  ): T[]
-
-  static getHorizontalLine<T>(
-    board: Cell[][],
-    line: number,
-    parser: CellParserCallback<T>
   ) {
     return parser
       ? board.map((e, i) => parser(e[line], i, line))
-      : board.map((e, i) => e[line])
+      : board.map((e) => e[line])
   }
 
   static getVerticalLine<T>(
-    board: Cell[][],
+    board: Cell[][] | TileOnBoard[][],
     line: number,
     parser: CellParserCallback<T>
   ) {

--- a/tests/Logic/types/word/Word.test.ts
+++ b/tests/Logic/types/word/Word.test.ts
@@ -33,7 +33,7 @@ describe('Word class', () => {
     it('Should update possibleWord', () => {
       EMPTY_TEST_BOARD[1][1].tile = { letter: 'A', points: 1 }
 
-      const line = Board.getHorizontalLine<Cell>(
+      const line = Board.getHorizontalLine(
         EMPTY_TEST_BOARD,
         1,
         Cell.parseTileFromCell
@@ -41,7 +41,7 @@ describe('Word class', () => {
 
       expect(line.some((e) => e.tile)).toBeTruthy()
 
-      const possibleWord = Word.getMissingLettersFromLine(1, line, new Word())
+      const possibleWord = Word.getMissingLettersFromLine(1, line, new TileOnBoardVector())
       //expect(possibleWord).toBe('BAD')
     })
   })


### PR DESCRIPTION
Generics aren't really the solution here, they're way too complicated for this use case.

Me & Lewis agree that composition is probably the easiest solution to this problem, where you have a single `Cell` class that has a nullable `Tile` property on it. Then you can easily check if a cell has a tile on it or not without any of this overloading & generic craziness.